### PR TITLE
add builtin macro __loongarch64__

### DIFF
--- a/gcc/config/loongarch/loongarch-c.c
+++ b/gcc/config/loongarch/loongarch-c.c
@@ -60,6 +60,7 @@ void loongarch_cpu_cpp_builtins (cpp_reader *pfile)
       builtin_define ("_ABILP64=3");
       builtin_define ("_LOONGARCH_SIM=_ABILP64");
       builtin_define ("__loongarch64");
+      builtin_define ("__loongarch64__");
       break;
     }
 


### PR DESCRIPTION
是否可以为loongarch64增加一个 `__loongarch64__` 内置宏？以体现对称美？

增加此补丁后的效果：
```
$ gcc -E -dM - < /dev/null |grep loongarch64
#define __loongarch64 1
#define __loongarch64__ 1
#define _LOONGARCH_ARCH "loongarch64"
#define _LOONGARCH_TUNE "loongarch64"
```