### PR TITLE
[proposal] loongarch: use "dbar 0x7fff" for LL/SC workaround

### DIFF
--- a/gcc/config/loongarch/sync.md
+++ b/gcc/config/loongarch/sync.md
@@ -130,7 +130,7 @@
   ""
 {
   if (FIX_LOONGSON3_LLSC)
-    return "%G5\n\t1:\n\tll.<amo>\t%0,%1\n\tbne\t%0,%z2,2f\n\tor%i3\t%6,$zero,%3\n\tsc.<amo>\t%6,%1\n\tbeq\t$zero,%6,1b\n\t2:\n\tdbar\t0";
+    return "%G5\n\t1:\n\tll.<amo>\t%0,%1\n\tbne\t%0,%z2,2f\n\tor%i3\t%6,$zero,%3\n\tsc.<amo>\t%6,%1\n\tbeq\t$zero,%6,1b\n\t2:\n\tdbar\t0x7fff";
   else
     return "%G5\n\t1:\n\tll.<amo>\t%0,%1\n\tbne\t%0,%z2,2f\n\tor%i3\t%6,$zero,%3\n\tsc.<amo>\t%6,%1\n\tbeq\t$zero,%6,1b\n\t2:";
 
@@ -228,7 +228,7 @@
   ""
 {
   if (FIX_LOONGSON3_LLSC)
-    return "%G6\n\t1:\n\tll.<amo>\t%0,%1\n\tand\t%7,%0,%2\n\tbne\t%7,%z4,2f\n\tand\t%7,%0,%z3\n\tor%i5\t%7,%7,%5\n\tsc.<amo>\t%7,%1\n\tbeq\t$zero,%7,1b\n\t2:\n\tdbar\t0";
+    return "%G6\n\t1:\n\tll.<amo>\t%0,%1\n\tand\t%7,%0,%2\n\tbne\t%7,%z4,2f\n\tand\t%7,%0,%z3\n\tor%i5\t%7,%7,%5\n\tsc.<amo>\t%7,%1\n\tbeq\t$zero,%7,1b\n\t2:\n\tdbar\t0x7fff";
   else
     return "%G6\n\t1:\n\tll.<amo>\t%0,%1\n\tand\t%7,%0,%2\n\tbne\t%7,%z4,2f\n\tand\t%7,%0,%z3\n\tor%i5\t%7,%7,%5\n\tsc.<amo>\t%7,%1\n\tbeq\t$zero,%7,1b\n\t2:";
 }


### PR DESCRIPTION
很遗憾，目前从 MIPS 时代祖传下来的 LL/SC 问题仍需要软件修复。这带来的问题是：如果将来在 3A6000 中修复了这个问题，现有的编译好的软件包在 3A6000 上仍然会不必要地执行 dbar，从而降低性能。而如果要避免性能损失，就必须为 3A6000 重新编译含有 LL/SC 指令的所有软件包。这非常麻烦，同时要求用户必须升级硬件才能使用新的软件包。

为此，我们可以给 dbar 加一个别的立即数，根据手册的规定，它在 3A5000 上没有专门实现，所以等价于 dbar 0；而在 3A6000 中修复 LL/SC 后，可以将其定义为“什么也不做”，从而避免性能损失。