### PR TITLE
use register name

### DIFF
--- a/gcc/config/loongarch/loongarch.h
+++ b/gcc/config/loongarch/loongarch.h
@@ -852,56 +852,86 @@ typedef struct {
 #define ASM_APP_OFF " #NO_APP\n"
 #endif
 
-#define REGISTER_NAMES							  \
-{ "$r0",   "$r1",   "$r2",   "$r3",   "$r4",   "$r5",   "$r6",   "$r7",   \
-  "$r8",   "$r9",   "$r10",  "$r11",  "$r12",  "$r13",  "$r14",  "$r15",  \
-  "$r16",  "$r17",  "$r18",  "$r19",  "$r20",  "$r21",  "$r22",  "$r23",  \
-  "$r24",  "$r25",  "$r26",  "$r27",  "$r28",  "$r29",  "$r30",  "$r31",  \
-  "$f0",  "$f1",  "$f2",  "$f3",  "$f4",  "$f5",  "$f6",  "$f7",	  \
-  "$f8",  "$f9",  "$f10", "$f11", "$f12", "$f13", "$f14", "$f15",	  \
-  "$f16", "$f17", "$f18", "$f19", "$f20", "$f21", "$f22", "$f23",	  \
-  "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31",	  \
-  "$fcc0","$fcc1","$fcc2","$fcc3","$fcc4","$fcc5","$fcc6","$fcc7",	  \
-  "$arg", "$frame"}
+#define REGISTER_NAMES								\
+{ "$zero", "$ra",   "$tp",   "$sp",   "$a0",   "$a1",   "$a2",   "$a3",		\
+  "$a4",   "$a5",   "$a6",   "$a7",   "$t0",   "$t1",   "$t2",   "$t3",		\
+  "$t4",   "$t5",   "$t6",   "$t7",   "$t8",   "$x",    "$fp",   "$s0",		\
+  "$s1",   "$s2",   "$s3",   "$s4",   "$s5",   "$s6",   "$s7",   "$s8",		\
+  "$fa0",  "$fa1",  "$fa2",  "$fa3",  "$fa4",  "$fa5",  "$fa6",  "$fa7",	\
+  "$ft0",  "$ft1",  "$ft2",  "$ft3",  "$ft4",  "$ft5",  "$ft6",  "$ft7",	\
+  "$ft8",  "$ft9",  "$ft10", "$ft11", "$ft12", "$ft13", "$ft14", "$ft15",	\
+  "$fs0",  "$fs1",  "$fs2",  "$fs3",  "$fs4",  "$fs5",  "$fs6",  "$fs7",	\
+  "$fcc0", "$fcc1", "$fcc2", "$fcc3", "$fcc4", "$fcc5", "$fcc6", "$fcc7",	\
+  "$arg",  "$frame"}
 
 /* This macro defines additional names for hard registers.  */
 
 #define ADDITIONAL_REGISTER_NAMES					\
 {									\
-  { "zero",	 0 + GP_REG_FIRST },					\
-  { "ra",	 1 + GP_REG_FIRST },					\
-  { "tp",	 2 + GP_REG_FIRST },					\
-  { "sp",	 3 + GP_REG_FIRST },					\
-  { "a0",	 4 + GP_REG_FIRST },					\
-  { "a1",	 5 + GP_REG_FIRST },					\
-  { "a2",	 6 + GP_REG_FIRST },					\
-  { "a3",	 7 + GP_REG_FIRST },					\
-  { "a4",	 8 + GP_REG_FIRST },					\
-  { "a5",	 9 + GP_REG_FIRST },					\
-  { "a6",	10 + GP_REG_FIRST },					\
-  { "a7",	11 + GP_REG_FIRST },					\
-  { "t0",	12 + GP_REG_FIRST },					\
-  { "t1",	13 + GP_REG_FIRST },					\
-  { "t2",	14 + GP_REG_FIRST },					\
-  { "t3",	15 + GP_REG_FIRST },					\
-  { "t4",	16 + GP_REG_FIRST },					\
-  { "t5",	17 + GP_REG_FIRST },					\
-  { "t6",	18 + GP_REG_FIRST },					\
-  { "t7",	19 + GP_REG_FIRST },					\
-  { "t8",	20 + GP_REG_FIRST },					\
-  { "x",	21 + GP_REG_FIRST },					\
-  { "fp",	22 + GP_REG_FIRST },					\
-  { "s0",	23 + GP_REG_FIRST },					\
-  { "s1",	24 + GP_REG_FIRST },					\
-  { "s2",	25 + GP_REG_FIRST },					\
-  { "s3",	26 + GP_REG_FIRST },					\
-  { "s4",	27 + GP_REG_FIRST },					\
-  { "s5",	28 + GP_REG_FIRST },					\
-  { "s6",	29 + GP_REG_FIRST },					\
-  { "s7",	30 + GP_REG_FIRST },					\
-  { "s8",	31 + GP_REG_FIRST },					\
-  { "v0",	 4 + GP_REG_FIRST },					\
-  { "v1",	 5 + GP_REG_FIRST }					\
+  { "r0",	 0 + GP_REG_FIRST },					\
+  { "r1",	 1 + GP_REG_FIRST },					\
+  { "r2",	 2 + GP_REG_FIRST },					\
+  { "r3",	 3 + GP_REG_FIRST },					\
+  { "r4",	 4 + GP_REG_FIRST },					\
+  { "r5",	 5 + GP_REG_FIRST },					\
+  { "r6",	 6 + GP_REG_FIRST },					\
+  { "r7",	 7 + GP_REG_FIRST },					\
+  { "r8",	 8 + GP_REG_FIRST },					\
+  { "r9",	 9 + GP_REG_FIRST },					\
+  { "r10",	10 + GP_REG_FIRST },					\
+  { "r11",	11 + GP_REG_FIRST },					\
+  { "r12",	12 + GP_REG_FIRST },					\
+  { "r13",	13 + GP_REG_FIRST },					\
+  { "r14",	14 + GP_REG_FIRST },					\
+  { "r15",	15 + GP_REG_FIRST },					\
+  { "r16",	16 + GP_REG_FIRST },					\
+  { "r17",	17 + GP_REG_FIRST },					\
+  { "r18",	18 + GP_REG_FIRST },					\
+  { "r19",	19 + GP_REG_FIRST },					\
+  { "r20",	20 + GP_REG_FIRST },					\
+  { "r21",	21 + GP_REG_FIRST },					\
+  { "r22",	22 + GP_REG_FIRST },					\
+  { "r23",	23 + GP_REG_FIRST },					\
+  { "r24",	24 + GP_REG_FIRST },					\
+  { "r25",	25 + GP_REG_FIRST },					\
+  { "r26",	26 + GP_REG_FIRST },					\
+  { "r27",	27 + GP_REG_FIRST },					\
+  { "r28",	28 + GP_REG_FIRST },					\
+  { "r29",	29 + GP_REG_FIRST },					\
+  { "r30",	30 + GP_REG_FIRST },					\
+  { "r31",	31 + GP_REG_FIRST },					\
+  { "f0",	 0 + FP_REG_FIRST },					\
+  { "f1",	 1 + FP_REG_FIRST },					\
+  { "f2",	 2 + FP_REG_FIRST },					\
+  { "f3",	 3 + FP_REG_FIRST },					\
+  { "f4",	 4 + FP_REG_FIRST },					\
+  { "f5",	 5 + FP_REG_FIRST },					\
+  { "f6",	 6 + FP_REG_FIRST },					\
+  { "f7",	 7 + FP_REG_FIRST },					\
+  { "f8",	 8 + FP_REG_FIRST },					\
+  { "f9",	 9 + FP_REG_FIRST },					\
+  { "f10",	10 + FP_REG_FIRST },					\
+  { "f11",	11 + FP_REG_FIRST },					\
+  { "f12",	12 + FP_REG_FIRST },					\
+  { "f13",	13 + FP_REG_FIRST },					\
+  { "f14",	14 + FP_REG_FIRST },					\
+  { "f15",	15 + FP_REG_FIRST },					\
+  { "f16",	16 + FP_REG_FIRST },					\
+  { "f17",	17 + FP_REG_FIRST },					\
+  { "f18",	18 + FP_REG_FIRST },					\
+  { "f19",	19 + FP_REG_FIRST },					\
+  { "f20",	20 + FP_REG_FIRST },					\
+  { "f21",	21 + FP_REG_FIRST },					\
+  { "f22",	22 + FP_REG_FIRST },					\
+  { "f23",	23 + FP_REG_FIRST },					\
+  { "f24",	24 + FP_REG_FIRST },					\
+  { "f25",	25 + FP_REG_FIRST },					\
+  { "f26",	26 + FP_REG_FIRST },					\
+  { "f27",	27 + FP_REG_FIRST },					\
+  { "f28",	28 + FP_REG_FIRST },					\
+  { "f29",	29 + FP_REG_FIRST },					\
+  { "f30",	30 + FP_REG_FIRST },					\
+  { "f31",	31 + FP_REG_FIRST },					\
 }
 
 /* Globalizing directive for a label.  */


### PR DESCRIPTION
这个补丁可以让 `gcc -S` 显示寄存器名称($zero)，而不是寄存器号($r0)。

~但副作用是，合并此补丁之后的gcc，只能编译使用了寄存器名的汇编，汇编代码如果使用寄存器号会报错，需要将相应的汇编代码修改过来，已知 binutils、linux 需要打补丁。~