### PR TITLE
LoongArch: Adjust floating point code gen for LTGT compare.

### DIFF
--- a/gcc/config/loongarch/loongarch.md
+++ b/gcc/config/loongarch/loongarch.md
@@ -588,7 +588,7 @@
 			 (lt "slt")
 			 (le "sle")
 			 (ordered "cor")
-			 (ltgt "cne")
+			 (ltgt "sne")
 			 (ne "cune")
 			 (ge "sge")
 			 (gt "sgt")


### PR DESCRIPTION
        commit 9069e9484cec2ff981c87c75b226ad738847ca07
        Author: Kito Cheng <kito.cheng@sifive.com>
        Date:   Mon Feb 24 10:54:21 2020 -0600

        RISC-V: Adjust floating point code gen for LTGT compare

        - Using gcc.dg/torture/pr91323.c as testcase, so no new testcase
          introduced.
        - According latest GCC document LTGT and discussion on pr91323
          LTGT should signals on NaNs, like GE/GT/LE/LT.
        - So we expand (LTGT a b) to ((LT a b) | (GT a b)) for fit the document.

        gcc/config/loongarch/
        * loongarch.md: Change the code gen for LTGT.