### PR TITLE
loongarch: fix default --with-arch setting for cross compiler

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2540,9 +2540,11 @@ loongarch64-*-linux*)
 	esac
 
 	# Setting default values for with_arch
-	# if we are cross-compiling.
+	# if we are cross-compiling or building a cross compiler.
 	# (otherwise it would default to "native")
-	if test x${cross_compiling} == xyes && test x${with_arch} == x; then
+	if { test x${cross_compiling} == xyes ||
+	     test x${host} != x${target} ; } && test x${with_arch} == x
+	then
 		with_arch=loongarch64
 	fi
 
@@ -4961,13 +4963,11 @@ case "${target}" in
 		loongarch64 | gs464v) ;; # OK
 		"" | native)
 			with_arch=native
-			case ${cross_compiling} in
-			no) ;; # OK
-			yes)
-				echo "--with-arch=native is illegal for a cross-compiler." 1>&2
+			if test x${cross_compiling} == xyes ||
+			   test x${host} != x${target}; then
+				echo "--with-arch=native is illegal for cross compiling or building cross compiler." 1>&2
 				exit 1
-				;;
-			esac
+			fi
 			;;
 		*)
 			echo "Unknown arch in --with-arch=$with_arch" 1>&2


### PR DESCRIPTION
Note that "cross compiling" and "building a cross compiler" are different.
However -march=native does not make sense for both of the cases.