### PR TITLE
loongarch: use loongarch64 as the default with_arch value

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2539,13 +2539,6 @@ loongarch64-*-linux*)
 	#	;;
 	esac
 
-	# Setting default values for with_arch
-	# if we are cross-compiling.
-	# (otherwise it would default to "native")
-	if test x${cross_compiling} == xyes && test x${with_arch} == x; then
-		with_arch=loongarch64
-	fi
-
 	# Setting default --with-multilib-list if multilib is enabled.
 	if test x$enable_multilib == xyes; then
 		if test x"${with_multilib_list}" = xdefault; then
@@ -4958,16 +4951,15 @@ case "${target}" in
 
 		# Perform final sanity checks.
 		case ${with_arch} in
+		"")
+			with_arch=loongarch64
+			;;
 		loongarch64 | gs464v) ;; # OK
-		"" | native)
-			with_arch=native
-			case ${cross_compiling} in
-			no) ;; # OK
-			yes)
-				echo "--with-arch=native is illegal for a cross-compiler." 1>&2
+		native)
+			if test x${host} != x${target}; then
+				echo "--with-arch=native is illegal for cross compiler." 1>&2
 				exit 1
-				;;
-			esac
+			fi
 			;;
 		*)
 			echo "Unknown arch in --with-arch=$with_arch" 1>&2


### PR DESCRIPTION
Rationales:

1. No upstreamed GCC ports use "native" as the default.  I don't think
   the upstream will accept this.
2. Using "native" as the default can cause severe trouble for distro
   maintainers.
3. Explicitly setting --with-arch=native when cross compiling actually
   *makes* sense: you can use a cross compiler (A) to cross compile a
   native compiler (B) for loongarch64 which uses -march=native by
   default.  Compiler B runs on loongarch64 so it can detect the
   loongarch64 CPU feature at runtime.  OTOH, the cross compiler, A,
   can't use -march=native because it generally does not run on a
   loongarch64 CPU.

gcc/

	* config.gcc: Use loongarch64 instead of native as the default
	  --with-arch setting.  And, accept --with-arch=native while
	  cross compiling, but reject it for cross compiler.