### PR TITLE
loongarch: match rt_sigframe definition with the kernel

### DIFF
--- a/libgcc/config/loongarch/linux-unwind.h
+++ b/libgcc/config/loongarch/linux-unwind.h
@@ -49,8 +49,6 @@ loongarch_fallback_frame_state (struct _Unwind_Context *context,
     {
       struct rt_sigframe
       {
-	u_int32_t ass[4]; /* Argument save space for o32.  */
-	u_int32_t trampoline[2];
 	siginfo_t info;
 	ucontext_t uc;
       } *rt_ = context->cfa;


### PR DESCRIPTION
In Huacai's V4 patch [1], two unused fields have been removed.

[1]: https://lore.kernel.org/linux-arch/20210927064300.624279-15-chenhuacai@loongson.cn/T/#u

libgcc/

	* config/loongarch/linux-unwind.h (rt_sigframe): Use the same
	  definition with the latest LoongArch kernel.