### PR TITLE
loongarch: fix stack probe code generation for clash protection

### DIFF
--- a/gcc/config/loongarch/loongarch.c
+++ b/gcc/config/loongarch/loongarch.c
@@ -1089,7 +1089,7 @@ loongarch_emit_probe_stack_range (HOST_WIDE_INT first, HOST_WIDE_INT size)
 {
   /* See if we have a constant small number of probes to generate.  If so,
      that's the easy case.  */
-  if (first + size <= 2048)
+  if (size <= 8 * PROBE_INTERVAL)
     {
       HOST_WIDE_INT i;
 


### PR DESCRIPTION
在编译 sudo-1.9.8p2 的时候发现编译器在启用 `-fstack-clash-protection` 时生成了一个不停写入内存的死循环，导致段错误。简化后的测试用例：

```c
extern void g(char *);

int f()
{
	char x[2400];
	g(x);
	return x[1];
}

```

编译出的函数入口汇编代码：

```
f:
	or	$r13,$r3,$r0
	or	$r12,$r13,$r0
.LPSRL0:
	addi.d	$r13,$r13,-2048
	addi.d	$r13,$r13,-2048
	st.d	$r0,$r13,0
	bne	$r13,$r12,.LPSRL0
        ...
```

显然该循环不会正常终止，并且最终会访问越界而触发段错误。

-------

"2048" is just too small.  When size is smaller than PROBE_INTERVAL,
rounded_size then became zero, and a dead loop stomping the memory until
segfault is generated.

Fix up the condition for unrolling this loop, to avoid this dead loop.
The value "8" is borrowed from PowerPC port.

gcc/

	* config/loongarch/loongarch.c
	  (loongarch_emit_probe_stack_range): Fix the condition for stack
	  probe loop unrolling, to avoid a dead loop causing segfault.