### PR TITLE
LoongArch: pass floating-point ABI option to assembler

### DIFF
--- a/gcc/config/loongarch/loongarch.h
+++ b/gcc/config/loongarch/loongarch.h
@@ -95,7 +95,7 @@
 #endif
 
 #undef ASM_SPEC
-#define ASM_SPEC "%{mabi=*} %{subtarget_asm_spec}"
+#define ASM_SPEC "%{mabi=*} %{mfloat-abi=*} %{subtarget_asm_spec}"
 
 /* Extra switches sometimes passed to the linker.  */
 


### PR DESCRIPTION
    gcc/config/loongarch/
    * loongarch.h: modified ASM_SPEC to include "%{mfloat-abi=*}".