### PR TITLE
Revert "LoongArch: add a missing #include statement."

### DIFF
--- a/gcc/config/loongarch/loongarch-cpu.h
+++ b/gcc/config/loongarch/loongarch-cpu.h
@@ -59,7 +59,6 @@ extern struct loongarch_rtx_cost_data loongarch_cpu_rtx_cost_data[];
 void cache_cpucfg ();
 int fill_native_cpu_config();
 
-#include "system.h"
 uint32_t get_native_prid();
 #endif
 


### PR DESCRIPTION
This reverts commit d73104deb16b978c9f8205ff78175fa75e08f69c.