### PR TITLE
LoongArch: update multiarch dirnames and target triplet handling script.

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -995,7 +995,7 @@ EOF
     k1om:Linux:*:*)
 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
 	exit ;;
-    loongarch32:Linux:*:* | loongarch64:Linux:*:* | loongarchx32:Linux:*:*)
+    loongarch*:Linux:*:*)
 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
 	exit ;;
     m32r*:Linux:*:*)

--- a/config.sub
+++ b/config.sub
@@ -1185,7 +1185,7 @@ case $cpu-$vendor in
 			| k1om \
 			| le32 | le64 \
 			| lm32 \
-			| loongarch32 | loongarch64 | loongarchx32 \
+			| loongarch64 | loongarch64sf | loongarch64nf \
 			| m32c | m32r | m32rle \
 			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k \
 			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x \

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2499,57 +2499,66 @@ riscv*-*-freebsd*)
 	gcc_cv_initfini_array=yes
 	;;
 
-loongarch64-*-linux*)
-	# Check and set --with- options according to the triplet.
-	case ${with_abi} in
-	lp64) ;; # OK
-	"")
-		# Setting default values for with_abi / with_float
-		# so that the compiler can still find the library dirs
-		# of the correct ABI type according to its target triplet
-		# even when multilib (search path suffix) is turned off
-		# (see config/loongarch/linux.h).
-		if test x${enable_multilib} != xyes; then
-			with_abi=lp64
-		fi
+loongarch*-linux*)
+	# Inferring ${with_} options from the triplet.
+	case ${target} in
+	loongarch64nf-*)
+		with_arch_triplet=loongarch64
+		with_abi_triplet=lp64
+		with_float_triplet=soft
 		;;
-	#)
-	#	echo "Incompatible options:" \
-	#	"--with-abi=${with_abi} and --target=${target}." 1>&2
-	#	exit 1
-	#	;;
-	esac
-
-	case ${with_float} in
-	none | single | double) ;; # OK
-	"")
-		# See the comment above.
-		if test x${enable_multilib} != xyes; then
-			with_float=double
-		fi
+	loongarch64sf-*)
+		with_arch_triplet=loongarch64
+		with_abi_triplet=lp64
+		with_float_triplet=single
 		;;
-	hard)
-		# Ambiguous, default to double.
-		with_float=double
+	loongarch64-*)
+		with_arch_triplet=loongarch64
+		with_abi_triplet=lp64
+		with_float_triplet="*"
 		;;
-	#)
-	#	echo "Incompatible options:" \
-	#	"--with-float=${with_float} and --target=${target}." 1>&2
-	#	exit 1
-	#	;;
+	*)
+		echo "Unsupported target ${target}." 1>&2
+		exit 1
 	esac
 
 	# Setting default value for with_arch.
 	if test x${with_arch} == x; then
-		with_arch=loongarch64
+		with_arch=${with_arch_triplet}
 	fi
 
-	# Setting default --with-multilib-list if multilib is enabled.
-	if test x$enable_multilib == xyes; then
-		if test x"${with_multilib_list}" = xdefault; then
-			with_multilib_list="lp64/double"
+	# Check and set --with- options according to the triplet.
+	case ${with_abi} in
+	"")
+		with_abi=${with_abi_triplet}
+		;;
+
+	${with_abi_triplet}) ;; # OK
+	*)
+		echo "Incompatible options:" \
+		"--with-abi=${with_abi} and --target=${target}." 1>&2
+		exit 1
+		;;
+	esac
+
+	case ${with_float} in
+	"")
+		if test x${with_float_triplet} == x*; then
+			case ${target} in
+			loongarch64-*) with_float_triplet=double ;;
+			esac
 		fi
-	fi
+
+		with_float=${with_float_triplet}
+		;;
+
+	${with_float_triplet}) ;; # OK
+	*)
+		echo "Incompatible options:" \
+		"--with-float=${with_float} and --target=${target}." 1>&2
+		exit 1
+		;;
+	esac
 
 	tm_file="dbxelf.h elfos.h gnu-user.h linux.h linux-android.h glibc-stdint.h ${tm_file}"
 	tm_file="${tm_file} loongarch/gnu-user.h loongarch/linux.h"
@@ -4983,8 +4992,8 @@ case "${target}" in
 		esac
 
 		case ${with_float} in
-		"" | none | single | double)  ;;   # OK, append here.
-		soft)  with_float=none   ;;
+		"" | soft | single | double)  ;;   # OK, append here.
+		none)  with_float=soft   ;;
 		*)
 			echo "Unknown fpu type used in --with-fpu=$with_fpu" 1>&2
 			exit 1
@@ -5002,7 +5011,7 @@ case "${target}" in
 		# Handle --with-multilib-list.
 		if test x$enable_multilib == xyes; then
 			# Handle --with-multilib-list=default.
-			if test x$"{with_multilib_list}" == xdefault; then
+			if test x${with_multilib_list} == xdefault; then
 				if test x${with_abi} != x && test x${with_float} != x; then
 					with_multilib_list="${with_abi}/${with_float}"
 				else

--- a/gcc/config/loongarch/loongarch-cpu.c
+++ b/gcc/config/loongarch/loongarch-cpu.c
@@ -36,12 +36,9 @@ const char* loongarch_cpu_strings[] = {
 
 #define N M_OPTION_NOT_SEEN
 struct loongarch_cpu_config loongarch_cpu_default_config[] = {
-  /* CPU_NATIVE */      { N, N, N, N,
-			  { N } },
-  /* CPU_LOONGARCH64 */ { ISA_LA64, ABI_LP64, ISA_DOUBLE_FLOAT, ABI_DOUBLE_FLOAT,
-			  { 1 } },
-  /* CPU_GS464V */      { ISA_LA64, ABI_LP64, ISA_DOUBLE_FLOAT, ABI_DOUBLE_FLOAT,
-			  { 1 } },
+  /* CPU_NATIVE */      { N, N, { N } },
+  /* CPU_LOONGARCH64 */ { ISA_LA64, ISA_DOUBLE_FLOAT, { 1 } },
+  /* CPU_GS464V */      { ISA_LA64, ISA_DOUBLE_FLOAT, { 1 } },
 };
 #undef N
 
@@ -108,9 +105,7 @@ uint32_t get_native_prid (void)
 
 int fill_native_cpu_config (void)
 {
-  int int_isa = -1, int_abi = -1;
-  int float_isa = -1, float_abi = -1;
-  int cpu_type = -1;
+  int int_isa = -1, float_isa = -1, cpu_type = -1;
 
   /* Fill: loongarch_cpu_default_config[CPU_NATIVE].isa_int
      With: Integer ISA (ARCH)
@@ -120,7 +115,6 @@ int fill_native_cpu_config (void)
     {
       case 0x02:
 	int_isa = ISA_LA64;
-	int_abi = ABI_LP64;
 	break;
     }
 
@@ -132,17 +126,14 @@ int fill_native_cpu_config (void)
     {
       case 0x07:
 	float_isa = ISA_DOUBLE_FLOAT;
-	float_abi = ABI_DOUBLE_FLOAT;
 	break;
 
       case 0x03:
 	float_isa = ISA_SINGLE_FLOAT;
-	float_abi = ABI_SINGLE_FLOAT;
 	break;
 
       case 0x00:
 	float_isa = ISA_SOFT_FLOAT;
-	float_abi = ABI_SOFT_FLOAT;
 	break;
     }
 
@@ -169,21 +160,13 @@ int fill_native_cpu_config (void)
     = loongarch_cpu_default_config [cpu_type];
 
   #define NATIVE_INT_ISA (loongarch_cpu_default_config[CPU_NATIVE].isa_int)
-  #define NATIVE_INT_ABI (loongarch_cpu_default_config[CPU_NATIVE].abi_int)
   #define NATIVE_FLOAT_ISA (loongarch_cpu_default_config[CPU_NATIVE].isa_float)
-  #define NATIVE_FLOAT_ABI (loongarch_cpu_default_config[CPU_NATIVE].abi_float)
 
   if (int_isa != -1 && NATIVE_INT_ISA != int_isa)
-    {
       NATIVE_INT_ISA = int_isa;
-      NATIVE_INT_ABI = int_abi;
-    }
 
   if (float_isa != -1 && NATIVE_FLOAT_ISA != float_isa)
-    {
       NATIVE_FLOAT_ISA = float_isa;
-      NATIVE_FLOAT_ABI = float_abi;
-    }
 
   loongarch_cpu_issue_rate [CPU_NATIVE]
     = loongarch_cpu_issue_rate [cpu_type];

--- a/gcc/config/loongarch/loongarch-cpu.h
+++ b/gcc/config/loongarch/loongarch-cpu.h
@@ -36,9 +36,7 @@ struct loongarch_isa_ext {
 
 struct loongarch_cpu_config {
     int isa_int;
-    int abi_int;
     int isa_float;
-    int abi_float;
     struct loongarch_isa_ext ext;
 };
 

--- a/gcc/config/loongarch/loongarch-opts.c
+++ b/gcc/config/loongarch/loongarch-opts.c
@@ -167,7 +167,7 @@ loongarch_handle_m_option_combinations (
 	    gcc_unreachable();
 	  }
 
-      /* Try inferring int abi from "-march" option.  */
+      /* Try inferring int ISA from "-march" option.  */
       else if (!cpu_arch_was_absent)
 	*isa_int
 	  = loongarch_cpu_default_config[*cpu_arch].isa_int;
@@ -185,24 +185,10 @@ loongarch_handle_m_option_combinations (
   /* 4. Compute integer ABI */
   if (LARCH_OPT_ABSENT(*abi_int))
     {
-      /* Try inferring int abi from -march first
-       * (or loongarch_cpu_default_config[].abi_int
-       * will not be effective under any circumstance).  */
-
-      if (int_isa_was_absent)
-	if (!cpu_arch_was_absent)
-	  *abi_int
-	    = loongarch_cpu_default_config[*cpu_arch].abi_int;
-
-	else if (DEFAULT_ABI_INT != M_OPTION_NOT_SEEN)
+      if (int_isa_was_absent && cpu_arch_was_absent
+	  && DEFAULT_ABI_INT != M_OPTION_NOT_SEEN)
 	  /* Fall back to configure-time default, if there is one.  */
 	  *abi_int = DEFAULT_ABI_INT;
-
-	else
-	  /* If there's no configure-time default for integer ABI,
-	   * infer it from the configure-time default of "-march".  */
-	  *abi_int
-	    = loongarch_cpu_default_config[*cpu_arch].abi_int;
 
       else
 	/* Try inferring int ABI from int ISA.  */
@@ -258,7 +244,7 @@ loongarch_handle_m_option_combinations (
 	    gcc_unreachable();
 	  }
 
-      /* Try inferring fp abi from "-march" option.  */
+      /* Try inferring fp ISA from "-march" option.  */
       else if (!cpu_arch_was_absent)
 	*isa_float = loongarch_cpu_default_config[*cpu_arch].isa_float;
 
@@ -275,25 +261,10 @@ loongarch_handle_m_option_combinations (
   /* 7. Compute floating-point ABI */
   if (LARCH_OPT_ABSENT(*abi_float))
     {
-      /* Try inferring fp abi from cpu_arch first
-	 (or loongarch_cpu_default_config[].abi_float
-	 will not be effective under any circumstance).
-	 */
-      if (float_isa_was_absent)
-
-	if (!cpu_arch_was_absent)
-	  *abi_float
-	    = loongarch_cpu_default_config[*cpu_arch].abi_float;
-
-	else if (DEFAULT_ABI_FLOAT != M_OPTION_NOT_SEEN)
+      if (float_isa_was_absent && cpu_arch_was_absent
+	  && DEFAULT_ABI_FLOAT != M_OPTION_NOT_SEEN)
 	  /* Fall back to configure-time default, if there is one.  */
 	  *abi_float = DEFAULT_ABI_FLOAT;
-
-	else
-	  /* If there's no configure-time default for floating-point ABI,
-	   * infer it from the configure-time default of "-march".  */
-	  *abi_float
-	    = loongarch_cpu_default_config[*cpu_arch].abi_float;
 
       else
 	/* Try inferring fp abi from fp isa.  */

--- a/gcc/config/loongarch/t-linux
+++ b/gcc/config/loongarch/t-linux
@@ -44,10 +44,10 @@ ifeq ($(filter __DISABLE_MULTILIB,$(tm_defines)),)
 
     MULTILIB_OSDIRNAMES += \
       mabi.lp64/mfloat-abi.soft=../lib64/soft$\
-      $(call if_multiarch,:loongarch64-linux-gnu/soft)
+      $(call if_multiarch,:loongarch64nf-linux-gnu)
 
     MULTILIB_OSDIRNAMES += \
       mabi.lp64/mfloat-abi.single=../lib64/single$\
-      $(call if_multiarch,:loongarch64-linux-gnu/single)
+      $(call if_multiarch,:loongarch64sf-linux-gnu)
 
 endif


### PR DESCRIPTION
Proposal: use the following strings for the "machine" field in LoongArch target triplets.
- loongarch64 (lp64/double)  --> (GNU/Linux canonical) `loongarch64-linux-gnu`
- loongarch64sf (lp64/single) -->                                     `loongarch64sf-linux-gnu`
- loongarch64nf (lp64/soft)     -->                                    `loongarch64nf-linux-gnu`
(to be continued...)

To compile programs with a "foreign" ABI to her distribution, a user may choose to build a cross toolchain with `--target=<triplet>`, or to simply install libraries of the target ABI type to their designated path (in multilib and/or multiarch flavor), then invoke the native compiler with the right `-march`/`-mabi`/`-mfloat-abi` options to do the job.