### PR TITLE
loongarch: don't define MAX_BITSIZE_MODE_ANY_INT

### DIFF
--- a/gcc/config/loongarch/loongarch-modes.def
+++ b/gcc/config/loongarch/loongarch-modes.def
@@ -27,9 +27,3 @@ VECTOR_MODES (FLOAT, 8);      /*       V4HF V2SF */
 CC_MODE (FCC);
 
 INT_MODE (OI, 32);
-
-/* Keep the OI modes from confusing the compiler into thinking
-   that these modes could actually be used for computation.  They are
-   only holders for vectors during data movement.  */
-#define MAX_BITSIZE_MODE_ANY_INT (128)
-


### PR DESCRIPTION
Despite it's defined, the compiler will still use OImode in computation.
Then this causes an out-of-array-bound access in wide_int, because
WIDE_INT_MAX_ELTS is calculated from a wrong MAX_BITSIZE_MODE_ANY_INT
value.  It can be triggered with a simple program and
-O -g -frounding-math -fexcess-precision=standard with address sanitizer:

    void t() { float f = 0xfffffffff; }

In the regresion test, it causes failures in
fp-uint64-convert-double-{1,2}.c.

All other ports don't define MAX_BITSIZE_MODE_ANY_INT and use the value
automatically calculated.