### PR TITLE
LoongArch: fix cross-compiler on 32-bit hosts.

### DIFF
--- a/gcc/config/loongarch/loongarch.c
+++ b/gcc/config/loongarch/loongarch.c
@@ -1432,8 +1432,8 @@ loongarch_expand_epilogue (bool sibcall_p)
     emit_jump_insn (gen_simple_return_internal (ra));
 }
 
-#define LU32I_B (0xfffffUL << 32)
-#define LU52I_B (0xfffUL << 52)
+#define LU32I_B (0xfffffULL << 32)
+#define LU52I_B (0xfffULL << 52)
 
 static unsigned int
 loongarch_build_integer (struct loongarch_integer_op *codes,
@@ -1486,7 +1486,7 @@ loongarch_build_integer (struct loongarch_integer_op *codes,
       codes[cost].value = ((value << 12) >> 44) << 32;
       cost++;
 
-      if (!lu52i[(value & (1UL << 51)) >> 51])
+      if (!lu52i[(value & (1ULL << 51)) >> 51])
 	{
 	  codes[cost].method = METHOD_LU52I;
 	  codes[cost].value = (value >> 52) << 52;

--- a/gcc/config/loongarch/loongarch.h
+++ b/gcc/config/loongarch/loongarch.h
@@ -626,12 +626,12 @@ enum reg_class
 /* True if VALUE can be loaded into a register using LU32I.  */
 
 #define LU32I_OPERAND(VALUE) \
-  (((VALUE) | (((1UL << 19) - 1) << 32)) == (((1UL << 19) - 1) << 32) \
-   || ((VALUE) | (((1UL << 19) - 1) << 32)) + (1UL << 32) == 0)
+  (((VALUE) | (((1ULL << 19) - 1) << 32)) == (((1ULL << 19) - 1) << 32) \
+   || ((VALUE) | (((1ULL << 19) - 1) << 32)) + (1ULL << 32) == 0)
 
 /* True if VALUE can be loaded into a register using LU52I.  */
 
-#define LU52I_OPERAND(VALUE) (((VALUE) | (0xfffUL << 52)) == (0xfffUL << 52))
+#define LU52I_OPERAND(VALUE) (((VALUE) | (0xfffULL << 52)) == (0xfffULL << 52))
 
 /* Return a value X with the low 12 bits clear, and such that
    VALUE - X is a signed 12-bit value.  */


### PR DESCRIPTION
**Problem:** Left-shifting a `UL` (`unsigned long`) literal by more than 31 bits may yield 0 on a 32-bit host, which is undesired.
To make a compile-time constant 64-bit bitmask by shifting literals, the suffix "ULL" should be used instead since its length is guaranteed to be at least 64-bit by C standard.